### PR TITLE
Optimizations for heavy multithreaded usage

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
     <packaging>bundle</packaging>
     <name>Apache Felix iPOJO</name>
     <artifactId>org.apache.felix.ipojo</artifactId>
-    <version>1.12.1-ullink1</version>
+    <version>1.12.1.2-ullink-SNAPSHOT</version>
 
     <properties>
         <!--
@@ -129,10 +129,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <target>1.5</target>
-                    <source>1.5</source>
-                    <testTarget>1.5</testTarget>
-                    <testSource>1.5</testSource>
+                    <target>1.6</target>
+                    <source>1.6</source>
+                    <testTarget>1.6</testTarget>
+                    <testSource>1.6</testSource>
                 </configuration>
             </plugin>
             <plugin>
@@ -357,7 +357,7 @@
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java15</artifactId>
+                        <artifactId>java16</artifactId>
                         <version>1.0</version>
                     </signature>
                 </configuration>

--- a/core/src/main/java/org/apache/felix/ipojo/InstanceManager.java
+++ b/core/src/main/java/org/apache/felix/ipojo/InstanceManager.java
@@ -1327,7 +1327,7 @@ public class InstanceManager implements ComponentInstance, InstanceStateListener
      * @param methodId the method id
      * @return the method object or <code>null</code> if the method cannot be found.
      */
-    private Member getMethodById(String methodId) {
+    private Member getMethodById(final String methodId) {
         // Used a synchronized map.
         Member member = (Member) m_methods.get(methodId);
         if (member == NO_METHOD) {
@@ -1342,7 +1342,7 @@ public class InstanceManager implements ComponentInstance, InstanceStateListener
                     return null;
                 } else {
                     String innerClassName = split[0];
-                    methodId = split[1];
+                    String innerMethodName = split[1];
 
                     // We can't find the member objects from anonymous methods, identified by their numeric name
                     // Just escaping in this case.
@@ -1355,16 +1355,17 @@ public class InstanceManager implements ComponentInstance, InstanceStateListener
                         if (innerClassName.equals(c.getSimpleName())) {
                             Method[] mets = c.getDeclaredMethods();
                             for (Method met : mets) {
-                                if (MethodMetadata.computeMethodId(met).equals(methodId)) {
+                                if (MethodMetadata.computeMethodId(met).equals(innerMethodName)) {
                                     // Store the new methodId
                                     m_methods.put(methodId, met);
                                     return met;
                                 }
                             }
                         }
-                        m_logger.log(Logger.INFO, "Cannot find the member associated to " + methodId + " - reason: " +
-                                "cannot find the class " + innerClassName + " declared in " + m_clazz.getName());
                     }
+                    m_logger.log(Logger.INFO, "Cannot find the member associated to " + methodId + " - reason: " +
+                        "cannot find the class " + innerClassName + " declared in " + m_clazz.getName());
+                    return null;
                 }
             }
 


### PR DESCRIPTION
Method cache was implemented using Collections.synchronizedMap()
which is bad under heavy multi threading usage
Replaced it with ConcurrentHashMap which is way better, with
a nice hack as it doesn't allow null values :o

+ optimized Dependency.onGet()