### PR TITLE
Fix concurrency issue with usages cache

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -131,8 +131,8 @@
                 <configuration>
                     <target>1.6</target>
                     <source>1.6</source>
-                    <testTarget>1.6</testTarget>
-                    <testSource>1.6</testSource>
+                    <testTarget>8</testTarget>
+                    <testSource>8</testSource>
                 </configuration>
             </plugin>
             <plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
     <packaging>bundle</packaging>
     <name>Apache Felix iPOJO</name>
     <artifactId>org.apache.felix.ipojo</artifactId>
-    <version>1.12.1.2-ullink-SNAPSHOT</version>
+    <version>1.12.1.3-ullink-SNAPSHOT</version>
 
     <properties>
         <!--

--- a/core/src/main/java/org/apache/felix/ipojo/handlers/dependency/ServiceUsage.java
+++ b/core/src/main/java/org/apache/felix/ipojo/handlers/dependency/ServiceUsage.java
@@ -18,13 +18,9 @@
  */
 package org.apache.felix.ipojo.handlers.dependency;
 
-import java.security.Provider;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Object managing thread local copy of required services.
@@ -37,7 +33,7 @@ public class ServiceUsage extends ThreadLocal<ServiceUsage.Usage> {
      * Structure contained in the Thread Local.
      */
     public static class Usage {
-        
+
         /**
          * Stack Size.
          */
@@ -46,7 +42,7 @@ public class ServiceUsage extends ThreadLocal<ServiceUsage.Usage> {
          * Object to inject.
          */
         private Object m_object;
-        
+
         /**
          * Tracks the number of component method called
          * in the current thread.
@@ -54,7 +50,7 @@ public class ServiceUsage extends ThreadLocal<ServiceUsage.Usage> {
         int m_componentStack = 0;
 
         private volatile boolean m_uptodate = false;
-        
+
         /**
          * Increment the stack level from the first
          * service get.
@@ -62,7 +58,7 @@ public class ServiceUsage extends ThreadLocal<ServiceUsage.Usage> {
         public void inc() {
             m_stack++;
         }
-        
+
         /**
          * Increment the component stack level.
          */
@@ -109,7 +105,7 @@ public class ServiceUsage extends ThreadLocal<ServiceUsage.Usage> {
      * Keep track of provided {@link Usage}s to be able to invalid them (see {@link #markOutdated()})
      * Weak reference based to avoid preventing the Usages from being GC'd
      */
-    private Set<Usage> usages = Collections.newSetFromMap(new WeakHashMap<Usage, Boolean>());
+    private Set<Usage> usages = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<Usage, Boolean>()));
 
     /**
      * Marks all associated {@link Usage} as not being up to date, meaning

--- a/core/src/test/java/org/apache/felix/ipojo/handlers/dependency/ServiceUsageTest.java
+++ b/core/src/test/java/org/apache/felix/ipojo/handlers/dependency/ServiceUsageTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.ipojo.handlers.dependency;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.felix.ipojo.InstanceManager;
+import org.apache.felix.ipojo.test.MockBundle;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+public class ServiceUsageTest
+{
+    ExecutorService threads = Executors.newCachedThreadPool();
+    Dependency dependency;
+    ServiceUsage serviceUsage;
+    Set<ServiceUsage.Usage> allUsages;
+
+    @Before
+    public void setup()
+    {
+        Bundle bundle = new MockBundle(Dependency.class.getClassLoader());
+        BundleContext context = Mockito.mock(BundleContext.class);
+        Mockito.when(context.getBundle()).thenReturn(bundle);
+        DependencyHandler handler = Mockito.mock(DependencyHandler.class);
+        dependency = new Dependency(handler, "a_field", Object.class, null, false, false, false,
+            false, "dep", context, Dependency.DYNAMIC_BINDING_POLICY, null, null, null);
+        dependency.start();
+        InstanceManager instanceManager = Mockito.mock(InstanceManager.class);
+        Mockito.when(handler.getInstanceManager()).thenReturn(instanceManager);
+        Mockito.when(instanceManager.getState()).thenReturn(InstanceManager.STOPPED);
+        serviceUsage = getPrivateField(dependency, "m_usage");
+        allUsages = getPrivateField(serviceUsage, "usages");
+    }
+
+    @Test
+    public void testUsageCachedByThread()
+    {
+        dependency.onEntry(null, null, null);
+        dependency.onGet(null, null, null);
+        ServiceUsage.Usage usage = serviceUsage.get();
+        dependency.onExit(null, null, null);
+        dependency.onFinally(null, null);
+        assertThat(serviceUsage.get()).isSameAs(usage);
+        dependency.onServiceModification(null);
+        assertThat(serviceUsage.get()).isSameAs(usage);
+    }
+
+    @Test
+    public void testUsageUpToDate() throws InterruptedException
+    {
+        assertThat(serviceUsage.get().isUpToDate()).isFalse();
+        allUsages.forEach( usages -> assertThat(usages.isUpToDate()).isFalse());
+        dependency.onGet(null, null, null);
+        assertThat(serviceUsage.get().isUpToDate()).isTrue();
+        Collection<Callable<Object>> runnables = new ArrayList<>();
+        for (int i=0; i< 10;  i++)
+            runnables.add(() -> dependency.onGet(null, null, null));
+        threads.invokeAll(runnables, 5, TimeUnit.SECONDS);
+        assertThat(allUsages.stream().filter(Objects::nonNull).map(ServiceUsage.Usage::isUpToDate).collect(Collectors.toList())).hasSize(11).containsOnly(true);
+        dependency.onServiceModification(null);
+        assertThat(serviceUsage.get().isUpToDate()).isFalse();
+        assertThat(allUsages.stream().filter(Objects::nonNull).map(ServiceUsage.Usage::isUpToDate).collect(Collectors.toList())).hasSize(11).containsOnly(false);
+        dependency.onExit(null, null, null);
+        dependency.onFinally(null, null);
+        dependency.onGet(null, null, null);
+        assertThat(serviceUsage.get().isUpToDate()).isTrue();
+    }
+
+    @Test
+    public void testWeakReference() throws InterruptedException
+    {
+        Collection<Callable<Object>> runnables = new ArrayList<>();
+        for (int i=0; i< 10;  i++)
+            runnables.add(() -> dependency.onGet(null, null, null));
+        threads.invokeAll(runnables, 5, TimeUnit.SECONDS);
+        assertThat(allUsages.stream().filter(Objects::nonNull).collect(Collectors.toList())).hasSize(10);
+        threads.shutdownNow();
+        Thread.sleep(500);
+        System.gc();
+        dependency.onGet(null, null, null);
+        List<ServiceUsage.Usage> usages = allUsages.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        assertThat(usages).hasSize(1);
+        assertThat(usages.get(0)).isSameAs(serviceUsage.get());
+    }
+
+    private static <T, C> T getPrivateField(C object, String fieldName)
+    {
+        try
+        {
+            Field field = object.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (T) field.get(object);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Use synchronizedSet.
No need for non blocking stuff, as the set is accessed only when a
thread first first use a "ipojo" instance (threads are cached in our
case) and when a service ref is updated (only at startup in our case).
Add tests