### PR TITLE
Fix compatibility with Java 11

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.apache.felix.ipojo.annotations</artifactId>
-    <version>1.12.1</version>
+    <version>1.12.1-ullink1-SNAPSHOT</version>
     <name>Apache Felix iPOJO Annotations</name>
 
     <description>
@@ -42,8 +42,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/ipojo-ant-task/pom.xml
+++ b/ipojo-ant-task/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.apache.felix.ipojo.ant</artifactId>
-    <version>1.12.1</version>
+    <version>1.12.1-ullink1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Apache Felix iPOJO Ant Task</name>
 
@@ -133,8 +133,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
 

--- a/manipulator-bom/pom.xml
+++ b/manipulator-bom/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>ipojo-manipulator-bom</artifactId>
-    <version>1.12.1</version>
+    <version>1.12.1-ullink1-SNAPSHOT</version>
   <name>Apache Felix iPOJO Manipulator BOM</name>
   <packaging>pom</packaging>
 

--- a/manipulator-bom/pom.xml
+++ b/manipulator-bom/pom.xml
@@ -33,7 +33,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <asm.version>5.0.2</asm.version>
+    <asm.version>7.3.1</asm.version>
     <metadata.version>1.6.0</metadata.version>
   </properties>
 
@@ -50,15 +50,24 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm-all</artifactId>
-        <version>${asm.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-tree</artifactId>
-          </exclusion>
-        </exclusions>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+          <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-tree</artifactId>
+          <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-util</artifactId>
+          <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-commons</artifactId>
+          <version>${asm.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.felix</groupId>

--- a/manipulator/pom.xml
+++ b/manipulator/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
     <artifactId>org.apache.felix.ipojo.manipulator</artifactId>
-    <version>1.12.1</version>
+    <version>1.12.1-ullink1-SNAPSHOT</version>
     <name>Apache Felix iPOJO Manipulator</name>
 
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.ipojo.annotations</artifactId>
-            <version>${project.version}</version>
+            <version>1.12.1</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/manipulator/pom.xml
+++ b/manipulator/pom.xml
@@ -40,8 +40,23 @@
     <dependencies>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.0.2</version>
+            <artifactId>asm</artifactId>
+            <version>7.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+            <version>7.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>7.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>7.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassChecker.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassChecker.java
@@ -73,7 +73,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
     private int m_classVersion;
 
     public ClassChecker() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     /**
@@ -345,7 +345,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
          * @param md the method descriptor of the visited method.
          */
         private MethodInfoCollector(MethodDescriptor md) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             m_method = md;
         }
 
@@ -456,7 +456,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
          * @param visible the visibility of the annotation at runtime
          */
         public AnnotationDescriptor(String name, boolean visible) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             m_name = name;
             m_visible = visible;
         }
@@ -469,7 +469,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
          * @param desc the descriptor of the annotation
          */
         public AnnotationDescriptor(String name, String desc) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             m_name = name;
             m_visible = true;
             m_desc = desc;
@@ -641,7 +641,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
          * @param name the name of the attribute.
          */
         public ArrayAttribute(String name) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             m_name = name;
         }
 
@@ -833,7 +833,7 @@ public class ClassChecker extends ClassVisitor implements Opcodes {
     private class InnerClassAssignedToStaticFieldDetector extends MethodVisitor {
 
         public InnerClassAssignedToStaticFieldDetector() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
         }
 
         @Override

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassManipulator.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassManipulator.java
@@ -141,7 +141,7 @@ public class ClassManipulator extends ClassVisitor implements Opcodes {
      * @param manipulator : the manipulator having analyzed the class.
      */
     public ClassManipulator(ClassVisitor visitor, Manipulator manipulator) {
-        super(Opcodes.ASM5, visitor);
+        super(Opcodes.ASM7, visitor);
         m_manipulator = manipulator;
         m_fields = manipulator.getFields().keySet();
         m_visitedMethods = manipulator.getMethods();

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassManipulator.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ClassManipulator.java
@@ -273,6 +273,7 @@ public class ClassManipulator extends ClassVisitor implements Opcodes {
      * @return FieldVisitor : null
      */
     public FieldVisitor visitField(final int access, final String name, final String desc, final String signature, final Object value) {
+        int newAccess = access;
         if ((access & ACC_STATIC) == 0) {
             FieldVisitor flag = cv.visitField(Opcodes.ACC_PRIVATE, FIELD_FLAG_PREFIX + name, "Z", null, null);
             flag.visitEnd();
@@ -297,8 +298,9 @@ public class ClassManipulator extends ClassVisitor implements Opcodes {
                 createSimpleSetter(name, sDesc, type);
             }
 
+            newAccess &= (~Opcodes.ACC_FINAL);
         }
-        return cv.visitField(access, name, desc, signature, value);
+        return cv.visitField(newAccess, name, desc, signature, value);
     }
 
     /**

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ConstructorCodeAdapter.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/ConstructorCodeAdapter.java
@@ -73,7 +73,7 @@ public class ConstructorCodeAdapter extends GeneratorAdapter implements Opcodes 
      * @param name   the name
      */
     public ConstructorCodeAdapter(final MethodVisitor mv, final String owner, Set<String> fields, int access, String name, String desc, String superClass) {
-        super(Opcodes.ASM5, mv, access, name, desc);
+        super(Opcodes.ASM7, mv, access, name, desc);
         m_owner = owner;
         m_superDetected = false;
         m_fields = fields;

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/InnerClassAdapter.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/InnerClassAdapter.java
@@ -72,7 +72,7 @@ public class InnerClassAdapter extends ClassVisitor implements Opcodes {
      */
     public InnerClassAdapter(String name, ClassVisitor visitor, String outerClassName,
                              Manipulator manipulator) {
-        super(Opcodes.ASM5, visitor);
+        super(Opcodes.ASM7, visitor);
         m_name = name;
         m_simpleName = m_name.substring(m_name.indexOf("$") + 1);
         m_outer = outerClassName;

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/InnerClassChecker.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/InnerClassChecker.java
@@ -34,7 +34,7 @@ public class InnerClassChecker extends ClassVisitor implements Opcodes {
     private final Manipulator m_manipulator;
 
     public InnerClassChecker(String name, Manipulator manipulator) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         m_name = name;
         m_manipulator = manipulator;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/MethodCodeAdapter.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulation/MethodCodeAdapter.java
@@ -53,7 +53,7 @@ public class MethodCodeAdapter extends GeneratorAdapter implements Opcodes {
      * @param fields : Contained fields
      */
     public MethodCodeAdapter(final MethodVisitor mv, final String owner, int access, String name, String desc, Set<String> fields) {
-        super(Opcodes.ASM5, mv, access, name, desc);
+        super(Opcodes.ASM7, mv, access, name, desc);
         m_owner = owner;
         m_fields = fields;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/ClassMetadataCollector.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/ClassMetadataCollector.java
@@ -58,7 +58,7 @@ public class ClassMetadataCollector extends ClassVisitor {
     private Element instanceMetadata;
 
     public ClassMetadataCollector(BindingRegistry registry, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.registry = registry;
         this.reporter = reporter;
         node = new ClassNode();

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/FieldMetadataCollector.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/FieldMetadataCollector.java
@@ -46,7 +46,7 @@ public class FieldMetadataCollector extends FieldVisitor {
     private FieldNode node;
 
     public FieldMetadataCollector(ComponentWorkbench workbench, FieldNode node) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.node = node;
         this.registry = workbench.getBindingRegistry();

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/MethodMetadataCollector.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/MethodMetadataCollector.java
@@ -47,7 +47,7 @@ public class MethodMetadataCollector extends MethodVisitor {
     private MethodNode node;
 
     public MethodMetadataCollector(ComponentWorkbench workbench, MethodNode node, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.node = node;
         this.registry = workbench.getBindingRegistry();

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/discovery/HandlerBindingDiscovery.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/discovery/HandlerBindingDiscovery.java
@@ -41,7 +41,7 @@ public class HandlerBindingDiscovery extends AnnotationVisitor implements Annota
      * Constructs a new {@link org.objectweb.asm.AnnotationVisitor}.
      */
     public HandlerBindingDiscovery() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     public AnnotationVisitor visitAnnotation(final String desc) {

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/parser/AnnotationTypeVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/parser/AnnotationTypeVisitor.java
@@ -34,7 +34,7 @@ public class AnnotationTypeVisitor extends ClassVisitor {
     private AnnotationType annotationType;
 
     public AnnotationTypeVisitor() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     @Override

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/parser/replay/AnnotationRecorder.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/model/parser/replay/AnnotationRecorder.java
@@ -33,7 +33,7 @@ public class AnnotationRecorder extends AnnotationVisitor implements Replay {
     private List<Replay> m_replays = new ArrayList<Replay>();
 
     public AnnotationRecorder() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     public void visit(final String name, final Object value) {

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ComponentVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ComponentVisitor.java
@@ -45,7 +45,7 @@ public class ComponentVisitor extends AnnotationVisitor {
     private ComponentWorkbench workbench;
 
     public ComponentVisitor(ComponentWorkbench workbench, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.reporter = reporter;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ControllerVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ControllerVisitor.java
@@ -37,7 +37,7 @@ public class ControllerVisitor extends AnnotationVisitor {
     private String field;
 
     public ControllerVisitor(ComponentWorkbench workbench, String field) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.field = field;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/FieldPropertyVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/FieldPropertyVisitor.java
@@ -82,7 +82,7 @@ public class FieldPropertyVisitor extends AnnotationVisitor {
      * @param field : field name.
      */
     public FieldPropertyVisitor(String field, Element parent) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         m_parent = parent;
         m_field = field;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerDeclarationVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerDeclarationVisitor.java
@@ -53,7 +53,7 @@ public class HandlerDeclarationVisitor extends AnnotationVisitor {
     private Reporter reporter;
 
     public HandlerDeclarationVisitor(ComponentWorkbench workbench, DocumentBuilder builder, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.builder = builder;
         this.reporter = reporter;

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/HandlerVisitor.java
@@ -41,7 +41,7 @@ public class HandlerVisitor extends AnnotationVisitor {
     private Reporter reporter;
 
     public HandlerVisitor(ComponentWorkbench workbench, Reporter reporter) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.reporter = reporter;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/InstantiateVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/InstantiateVisitor.java
@@ -38,7 +38,7 @@ public class InstantiateVisitor extends AnnotationVisitor {
     private ComponentWorkbench workbench;
 
     public InstantiateVisitor(ComponentWorkbench workbench) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
     }
 

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/LifecycleVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/LifecycleVisitor.java
@@ -42,7 +42,7 @@ public class LifecycleVisitor extends AnnotationVisitor {
     private Transition transition;
 
     public LifecycleVisitor(ComponentWorkbench workbench, String name, Transition transition) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.name = name;
         this.transition = transition;

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/MethodPropertyVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/MethodPropertyVisitor.java
@@ -73,7 +73,7 @@ public class MethodPropertyVisitor extends AnnotationVisitor {
      * @param method : attached method.
      */
     public MethodPropertyVisitor(Element parent, String method) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         m_parent = parent;
         m_method = method;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/PostRegistrationVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/PostRegistrationVisitor.java
@@ -35,7 +35,7 @@ public class PostRegistrationVisitor extends AnnotationVisitor {
     private String name;
 
     public PostRegistrationVisitor(ComponentWorkbench workbench, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.name = name;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/PostUnregistrationVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/PostUnregistrationVisitor.java
@@ -35,7 +35,7 @@ public class PostUnregistrationVisitor extends AnnotationVisitor {
     private String name;
 
     public PostUnregistrationVisitor(ComponentWorkbench workbench, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.name = name;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ProvidesVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ProvidesVisitor.java
@@ -42,7 +42,7 @@ public class ProvidesVisitor extends AnnotationVisitor {
     private Element m_prov = new Element("provides", "");
 
     public ProvidesVisitor(ComponentWorkbench workbench) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
     }
 
@@ -75,7 +75,7 @@ public class ProvidesVisitor extends AnnotationVisitor {
         } else if (name.equals("properties")) {
             // Create a new simple visitor to visit the nested ServiceProperty annotations
             // Collected properties are collected in m_prov
-            return new AnnotationVisitor(Opcodes.ASM5) {
+            return new AnnotationVisitor(Opcodes.ASM7) {
                 public AnnotationVisitor visitAnnotation(String ignored, String desc) {
                     return new FieldPropertyVisitor(m_prov);
                 }
@@ -104,7 +104,7 @@ public class ProvidesVisitor extends AnnotationVisitor {
 
 
         public InterfaceArrayVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
         }
 
         /**

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/RequiresVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/RequiresVisitor.java
@@ -106,7 +106,7 @@ public class RequiresVisitor extends AnnotationVisitor {
      * @param name : field name.
      */
     public RequiresVisitor(ComponentWorkbench workbench, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.m_field = name;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ServiceControllerVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/ServiceControllerVisitor.java
@@ -48,7 +48,7 @@ public class ServiceControllerVisitor extends AnnotationVisitor {
      * @param field : field name.
      */
     public ServiceControllerVisitor(String field, Element provides) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.provides = provides;
         controller.addAttribute(new Attribute("field", field));
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/UpdatedVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/UpdatedVisitor.java
@@ -36,7 +36,7 @@ public class UpdatedVisitor extends AnnotationVisitor {
     private String name;
 
     public UpdatedVisitor(ComponentWorkbench workbench, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.name = name;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/bind/AbstractBindVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/bind/AbstractBindVisitor.java
@@ -36,7 +36,7 @@ public abstract class AbstractBindVisitor extends AnnotationVisitor {
     protected Action action;
 
     public AbstractBindVisitor(ComponentWorkbench workbench, Action action) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.workbench = workbench;
         this.action = action;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/generic/GenericVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/generic/GenericVisitor.java
@@ -35,7 +35,7 @@ public class GenericVisitor extends AnnotationVisitor {
     protected Element element;
 
     public GenericVisitor(Element element) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.element = element;
     }
 

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/generic/SubArrayVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/generic/SubArrayVisitor.java
@@ -54,7 +54,7 @@ public class SubArrayVisitor extends AnnotationVisitor {
      * @param name : attribute name.
      */
     public SubArrayVisitor(Element elem, String name) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         m_elem = elem;
         m_name = name;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/FieldStereotypeVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/FieldStereotypeVisitor.java
@@ -34,7 +34,7 @@ public class FieldStereotypeVisitor extends AnnotationVisitor {
     private final AnnotationType m_annotationType;
 
     public FieldStereotypeVisitor(final FieldVisitor delegate, AnnotationType annotationType) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.m_delegate = delegate;
         m_annotationType = annotationType;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/MethodStereotypeVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/MethodStereotypeVisitor.java
@@ -34,7 +34,7 @@ public class MethodStereotypeVisitor extends AnnotationVisitor {
     private final AnnotationType m_annotationType;
 
     public MethodStereotypeVisitor(final MethodVisitor delegate, AnnotationType annotationType) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.m_delegate = delegate;
         m_annotationType = annotationType;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/ParameterStereotypeVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/ParameterStereotypeVisitor.java
@@ -37,7 +37,7 @@ public class ParameterStereotypeVisitor extends AnnotationVisitor {
     private final AnnotationType m_annotationType;
 
     public ParameterStereotypeVisitor(final MethodVisitor delegate, final int index, AnnotationType annotationType) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.m_delegate = delegate;
         this.index = index;
         m_annotationType = annotationType;

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/TypeStereotypeVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/metadata/annotation/visitor/stereotype/TypeStereotypeVisitor.java
@@ -36,7 +36,7 @@ public class TypeStereotypeVisitor extends AnnotationVisitor {
     private final AnnotationType m_annotationType;
 
     public TypeStereotypeVisitor(final ClassVisitor delegate, AnnotationType annotationType) {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
         this.m_delegate = delegate;
         m_annotationType = annotationType;
     }

--- a/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/util/ChainedAnnotationVisitor.java
+++ b/manipulator/src/main/java/org/apache/felix/ipojo/manipulator/util/ChainedAnnotationVisitor.java
@@ -35,7 +35,7 @@ public class ChainedAnnotationVisitor extends AnnotationVisitor {
     private List<AnnotationVisitor> m_visitors = new ArrayList<AnnotationVisitor>();
 
     public ChainedAnnotationVisitor() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     public List<AnnotationVisitor> getVisitors() {

--- a/manipulator/src/test/java/org/apache/felix/ipojo/manipulation/ClassCheckerTestCase.java
+++ b/manipulator/src/test/java/org/apache/felix/ipojo/manipulation/ClassCheckerTestCase.java
@@ -91,7 +91,7 @@ public class ClassCheckerTestCase extends TestCase {
         assertEquals(1, annotations.size());
         ClassChecker.AnnotationDescriptor annotationDescriptor = annotations.get(0);
         MethodVisitor mv = mock(MethodVisitor.class);
-        when(mv.visitAnnotation(desc, true)).thenReturn(new AnnotationVisitor(Opcodes.ASM5) {});
+        when(mv.visitAnnotation(desc, true)).thenReturn(new AnnotationVisitor(Opcodes.ASM7) {});
         annotationDescriptor.visitAnnotation(mv);
     }
 


### PR DESCRIPTION
A bit hack'ish but it seems to do the job
Basically targeting ASM 7.3.1 and removing the final modifiers on class fields as the current implementation uses the generated setters to initialize final fields in the constructor which is no longer allowed